### PR TITLE
fix(#54) : 사망 후에 점프 버튼 누르면 캐릭터 조금씩 내려가는 버그 수정

### DIFF
--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -237,8 +237,8 @@ public class CookieController : MonoBehaviour {
 		_ignoreGroundTimer += Time.deltaTime;
 		
 		// 점프 요청되었다면 점프
-		if (_jumpRequested && JumpEnabled) {
-			if (_state == CookieState.Run || _state == CookieState.Slide || _state == CookieState.Death) {
+		if (_jumpRequested && JumpEnabled && _state != CookieState.Death) {
+			if (_state == CookieState.Run || _state == CookieState.Slide) {
 				_ignoreGroundTimer = 0f;
 				_state = CookieState.Jump;
 				_cookieBehavior.StartJumpAnimation();


### PR DESCRIPTION
## 작업 브랜치
`fix/54-jump-after-death`

## 작업 요약
사망 후에 점프 버튼을 누르면 캐릭터가 조금씩 아래로 내려가는 버그를 수정하였습니다.


## 관련 이슈
close #54 

## 확인 사항
- [ ] 로컬에서 빌드 또는 실행을 확인했습니다.
- [ ] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
