### PR TITLE
Feature/75 아이템 종료 후 무적

### DIFF
--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -14,7 +14,7 @@ public class CookieController : MonoBehaviour {
 	private float _currentHp;
 	private float _additionalHp;
 	
-	private readonly float _godModeDuration = 2f;
+	private readonly float _godModeDurationAfterHit = 2f;
 	private bool _isGodMode = false;
 	private bool _isDashing = false;
 	private bool _isGiantMode = false;
@@ -169,14 +169,20 @@ public class CookieController : MonoBehaviour {
 		// 부딫혔을 때 이벤트 활성화
 		OnTakeDamage?.Invoke();
 		// 무적 상태 활성화
-		_coGodMode = StartCoroutine(CoGodMode());
+		EnableGodMode(_godModeDurationAfterHit);
 	}
 	
-	public IEnumerator CoGodMode() {
+	public void EnableGodMode(float duration) {
+		if (_coGodMode != null) StopCoroutine(_coGodMode);
+		_coGodMode = StartCoroutine(CoGodMode(duration));
+	} 
+	
+	// 실제 무적모드 효과 연출 및 무적 적용
+	private IEnumerator CoGodMode(float duration) {
 		_isGodMode = true;
 		float godModeTimer = 0f;
 		
-		while (godModeTimer <= _godModeDuration) {
+		while (godModeTimer <= duration) {
 			godModeTimer += Time.deltaTime;
 			if ((int)(godModeTimer / 0.1) % 2 == 0) {
 				_spriteRenderer.enabled = false;

--- a/Assets/Scripts/GamePlay/GameManager.cs
+++ b/Assets/Scripts/GamePlay/GameManager.cs
@@ -28,6 +28,7 @@ public class GameManager : MonoBehaviour {
 	private Vector3 _initialCookieScale;
 	private readonly float _giantScaleMultiplier = 3f;
 	private readonly float _dashSpeedMultiplier = 1.5f;
+	private readonly float _godmodeDurationAfterItem = 1.0f;
 	
 	private StageData _currentStage;
 	private float _scrollSpeed;
@@ -125,6 +126,8 @@ public class GameManager : MonoBehaviour {
 		yield return StartCoroutine(CoGrowToGiant(false));
 		// 거인모드 비활성화
 		_cookieController.IsGiantMode = false;
+		// 종료 시 무적모드 1초간 활성화
+		_cookieController.EnableGodMode(_godmodeDurationAfterItem);
 		
 		_coGiant = null;
 	}
@@ -161,6 +164,8 @@ public class GameManager : MonoBehaviour {
 		_cookieController.IsDashing = false;
 		// 스크롤 속도 원상복귀
 		_scrollSpeed = _initialScrollSpeed;
+		// 종료 시 무적모드 1초간 활성화
+		_cookieController.EnableGodMode(_godmodeDurationAfterItem);
 		
 		_coDash = null;
 	}

--- a/Assets/Scripts/Ui/Gacha/BbobgiTitle.cs
+++ b/Assets/Scripts/Ui/Gacha/BbobgiTitle.cs
@@ -1,8 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using TMPro;
-using UnityEditor;
-using UnityEditor.Overlays;
 using UnityEngine;
 using UnityEngine.UI;
 using SaveDataVC = SaveDataV1;
@@ -239,11 +236,11 @@ public class BbobgiTitle : GenericWindow
         {
             Destroy(child.gameObject);
         }
-        for (int i = 0; i < rewardList.Count; i++)
+        for (int i = 0; i < rewardGearList.Count; i++)
         {
             GameObject go = Instantiate(rewardPrefab,contentArea);
             go.SetActive(true); // 나중에 바꿀예정 테스트용
-            go.transform.GetChild(0).GetComponent<Image>().sprite = rewardList[i].Icon;
+            go.transform.GetChild(0).GetComponent<Image>().sprite = rewardGearList[i].Icon;
             yield return new WaitForSeconds(0.5f);
         }
         exitable = true;


### PR DESCRIPTION
## 작업 브랜치
feature/75-godmode-after-item

## 작업 요약
거대화, 대쉬 아이템 적용 종료 이후 1초간 무적 시간이 적용되도록 하였습니다.

## 변경 내용
- 거대화 이후 무적 시간 적용
- 대쉬 이후 무적 시간 적용

## 관련 이슈
close #75 

## 확인 사항
- [ ] 로컬에서 빌드 또는 실행을 확인했습니다.
- [ ] 변경 범위와 관련된 테스트를 확인했습니다.
