### PR TITLE
Fix/92 stage 2 fall

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -2744,17 +2744,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aa827a90845c02346871b93b67e09caf, type: 3}
---- !u!114 &1753349384 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7242597582833930819, guid: aa827a90845c02346871b93b67e09caf, type: 3}
-  m_PrefabInstance: {fileID: 1753349383}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2aae910561bb89e438515dc574f2d9da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ChangeScene
 --- !u!1 &1771133921
 GameObject:
   m_ObjectHideFlags: 0
@@ -3194,7 +3183,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6bfe10c195bd7944c98af3ef261679bc, type: 2}
   - {fileID: 11400000, guid: 587582f884a93654695e1fae6ec14bc3, type: 2}
   InvisibleGround: {fileID: 1628101516}
-  _changeScene: {fileID: 1753349384}
+  _changeScene: {fileID: 0}
 --- !u!1 &1918267843
 GameObject:
   m_ObjectHideFlags: 0
@@ -3566,6 +3555,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2514233627556925859, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: m_Size.y
+      value: 2.35
+      objectReference: {fileID: 0}
     - target: {fileID: 2615641987897293069, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: m_GravityScale
       value: 8
@@ -3605,6 +3598,18 @@ PrefabInstance:
     - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: _linearVelocityMax
       value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: m_Size.x
+      value: 0.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: m_Size.y
+      value: 0.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: m_Offset.y
+      value: 0.11
       objectReference: {fileID: 0}
     - target: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -329,12 +329,16 @@ public class CookieController : MonoBehaviour {
 				_state = CookieState.Jump;
 				_cookieBehavior.StartJumpAnimation();
 				
+				// 점프하면 포지션 값 초기화
+				SetStandingPosition();
+				SetStandingCollider();
+				
 				_rigidBody.linearVelocity = new Vector2(0, _jumpForce);
 			}
 			
 			else if (_state == CookieState.Jump) {
 				_state = CookieState.DoubleJump;
-				_cookieBehavior.StartDoubleJumpAnimation();
+				_cookieBehavior.StartDoubleJumpAnimation();	
 				
 				_rigidBody.linearVelocity = new Vector2(0, _jumpForce);
 			}

--- a/Assets/Scripts/GameResult/GameResultManager.cs
+++ b/Assets/Scripts/GameResult/GameResultManager.cs
@@ -144,7 +144,7 @@ public class GameResultManager : MonoBehaviour {
 			_scoreText.text = ((int)Mathf.Lerp(0, _score, timer / _lerpDuration)).ToString("N0");
 			yield return null;
 		}
-		_scoreText.text = _earnedCoin.ToString("N0");
+		_scoreText.text = _score.ToString("N0");
 		yield return new WaitForSeconds(_appearPeriod);
 		
 		// Best Score 표시? 혹은 안하기?


### PR DESCRIPTION
## 작업 브랜치
fix/92-stage-2-fall

## 작업 요약
슬라이딩 중 점프 시 콜라이더 크기 복원되지 않던 문제 수정
PlayScene 내부 MagnetArea에 CookieController가 에디터에서 연결되어있지 않던 문제 수정
결과 창에서 Score값이 이상하게 적용되었던 문제 수정

## 현재 상황
위의 문제들은 해결하였으나, 여전히 스테이지 2에서 바닥으로 빠지는 문제 존재하는 것으로 보임

## 관련 이슈
#92 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
