### PR TITLE
Feature/107 gear to play UI

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -1370,6 +1370,7 @@ GameObject:
   - component: {fileID: 692747395}
   - component: {fileID: 692747394}
   - component: {fileID: 692747393}
+  - component: {fileID: 692747396}
   m_Layer: 5
   m_Name: Gear 1
   m_TagString: Untagged
@@ -1391,6 +1392,7 @@ RectTransform:
   m_Children:
   - {fileID: 1995931716}
   - {fileID: 1503560011}
+  - {fileID: 1237831492}
   m_Father: {fileID: 634574587}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1456,6 +1458,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 692747391}
   m_CullTransparentMesh: 1
+--- !u!114 &692747396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 692747391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3920333806f54dda8a53311845dcd1b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InGameGearSlot
+  _progressBar: {fileID: 1503560012}
+  _shineEffect: {fileID: 1237831493}
+--- !u!1 &702772407
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 702772408}
+  m_Layer: 0
+  m_Name: GearSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &702772408
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 702772407}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 0.6666667}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1089295749770407401}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &710067087
 GameObject:
   m_ObjectHideFlags: 0
@@ -2297,7 +2344,7 @@ MonoBehaviour:
   WhileButtonPressed:
     m_PersistentCalls:
       m_Calls: []
---- !u!1 &1083440359
+--- !u!1 &1077490645
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2305,29 +2352,73 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1083440360}
-  m_Layer: 0
-  m_Name: GearSlot
+  - component: {fileID: 1077490646}
+  - component: {fileID: 1077490648}
+  - component: {fileID: 1077490647}
+  m_Layer: 5
+  m_Name: ShineEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1083440360
-Transform:
+--- !u!224 &1077490646
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1083440359}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1077490645}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1089295749770407401}
+  m_Father: {fileID: 1465974899}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.000030517578, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1077490647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077490645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -2086102200993970004, guid: 4904755544ab6d94e9bdaa448b985d24, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1077490648
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077490645}
+  m_CullTransparentMesh: 1
 --- !u!1 &1099367395
 GameObject:
   m_ObjectHideFlags: 0
@@ -2531,6 +2622,81 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7580611776035681038, guid: fd78dc413241e8442adb92e181313721, type: 3}
   m_PrefabInstance: {fileID: 1119937293}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1237831491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1237831492}
+  - component: {fileID: 1237831494}
+  - component: {fileID: 1237831493}
+  m_Layer: 5
+  m_Name: ShineEffect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1237831492
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237831491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 692747392}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.000091552734, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1237831493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237831491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -2086102200993970004, guid: 4904755544ab6d94e9bdaa448b985d24, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1237831494
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1237831491}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1245311534
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2753,6 +2919,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1447201461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1447201462}
+  - component: {fileID: 1447201464}
+  - component: {fileID: 1447201463}
+  m_Layer: 5
+  m_Name: ShineEffect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1447201462
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1447201461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1798723960}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.000022888184, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1447201463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1447201461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -2086102200993970004, guid: 4904755544ab6d94e9bdaa448b985d24, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1447201464
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1447201461}
+  m_CullTransparentMesh: 1
 --- !u!1 &1464115433
 GameObject:
   m_ObjectHideFlags: 0
@@ -2818,6 +3059,7 @@ RectTransform:
   m_Children:
   - {fileID: 1797183579}
   - {fileID: 1733745172}
+  - {fileID: 1077490646}
   m_Father: {fileID: 634574587}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2896,6 +3138,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::InGameGearSlot
   _progressBar: {fileID: 1733745173}
+  _shineEffect: {fileID: 1077490647}
 --- !u!1 &1476355980
 GameObject:
   m_ObjectHideFlags: 0
@@ -3914,6 +4157,7 @@ RectTransform:
   m_Children:
   - {fileID: 1275597704}
   - {fileID: 385393061}
+  - {fileID: 1447201462}
   m_Father: {fileID: 634574587}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3992,6 +4236,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::InGameGearSlot
   _progressBar: {fileID: 385393062}
+  _shineEffect: {fileID: 1447201463}
 --- !u!1 &1812971356
 GameObject:
   m_ObjectHideFlags: 0
@@ -4397,9 +4642,12 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6bfe10c195bd7944c98af3ef261679bc, type: 2}
   - {fileID: 11400000, guid: 587582f884a93654695e1fae6ec14bc3, type: 2}
   InvisibleGround: {fileID: 1628101516}
-  _firstGear: {fileID: 0}
-  _secondGearImage: {fileID: 0}
-  _thirdGearImage: {fileID: 0}
+  _firstGearSlot: {fileID: 692747396}
+  _secondGearSlot: {fileID: 1798723964}
+  _thirdGearSlot: {fileID: 1465974903}
+  _firstGearImage: {fileID: 1995931718}
+  _secondGearImage: {fileID: 1275597706}
+  _thirdGearImage: {fileID: 1797183581}
   _changeScene: {fileID: 1753349384}
 --- !u!1 &1918267843
 GameObject:
@@ -4907,7 +5155,7 @@ PrefabInstance:
     - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: gearPrefabParent
       value: 
-      objectReference: {fileID: 1083440360}
+      objectReference: {fileID: 702772408}
     - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: _linearVelocityMax
       value: 22
@@ -4973,7 +5221,7 @@ PrefabInstance:
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1083440360}
+      addedObject: {fileID: 702772408}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 4452933684968082351, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       insertIndex: -1

--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
@@ -417,6 +418,8 @@ public class CookieController : MonoBehaviour {
 	private void SetGear()
 	{
         string[] gearIds = SaveLoadManager.Data.currentGear;
+        List<GearBase> gears = new List<GearBase>();
+        List<GearData> gearDatas = new List<GearData>();
 
         foreach (string id in gearIds)
         {
@@ -426,13 +429,18 @@ public class CookieController : MonoBehaviour {
 			// 추하게 들고오긴 했음..
             var gearData = DataTableManager.GearTable.Get(id);
 			var gearPrefab = GameObject.FindGameObjectWithTag("SceneManager").GetComponent<GachaManager>().itemList.Find(g => g.itemId == id).GearPrefab;
+			gearDatas.Add(gearData);
             
 			if (gearData != null && gearPrefab != null)
             {
                 GameObject gearObj = Instantiate(gearPrefab, gearPrefabParent);
-
+                gears.Add(gearObj.GetComponent<GearBase>());
                 Debug.Log($"{id} 보물이 {gearPrefabParent.name} 아래에 생성되었습니다.");
             }
         }
+        
+        // UI에도 유물 세팅하기
+        _gameManager.SetGears(gears);
+        _gameManager.SetGearImages(gearDatas);
     }
 }

--- a/Assets/Scripts/GamePlay/GameManager.cs
+++ b/Assets/Scripts/GamePlay/GameManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -26,10 +27,14 @@ public class GameManager : MonoBehaviour {
 	[SerializeField] private StageData[] _stageDatas;
 	[SerializeField] public GameObject InvisibleGround;
 	
+	[Header("=== 착용한 유물을 각각 표현할 1, 2, 3번 슬롯 ===")]
+	[SerializeField] private InGameGearSlot _firstGearSlot;
+	[SerializeField] private InGameGearSlot _secondGearSlot;
+	[SerializeField] private InGameGearSlot _thirdGearSlot;
 	[Header("=== 착용한 유물을 각각 표현할 1, 2, 3번 이미지 ===")]
-	[SerializeField] private InGameGearSlot _firstGear;
-	[SerializeField] private InGameGearSlot _secondGearImage;
-	[SerializeField] private InGameGearSlot _thirdGearImage;
+	[SerializeField] private Image _firstGearImage;
+	[SerializeField] private Image _secondGearImage;
+	[SerializeField] private Image _thirdGearImage;
 
 	[SerializeField] private ChangeScene _changeScene;
 	
@@ -86,10 +91,17 @@ public class GameManager : MonoBehaviour {
 	}
 	
 	// 유물 설정하기, 없다면 입력 안해도 됨
-	public void SetGears(GearBase firstGear = null, GearBase secondGear = null, GearBase thirdGear = null) {
-		_firstGear.Init(firstGear);
-		_secondGearImage.Init(secondGear);
-		_thirdGearImage.Init(thirdGear);
+	public void SetGears(List<GearBase> gears) {
+		_firstGearSlot.Init(gears.Count >= 1 ? gears[0] : null);
+		_secondGearSlot.Init(gears.Count >= 2 ? gears[1] : null);
+		_thirdGearSlot.Init(gears.Count >= 3 ? gears[2] : null);
+	}
+	
+	// 유물 이미지 설정하기, 역시 없다면 입력 안 해도 됨
+	public void SetGearImages(List<GearData> gears) {
+		_firstGearImage.sprite = gears.Count >= 1 ? gears[0].SpriteIcon : null;
+		_secondGearImage.sprite = gears.Count >= 2 ? gears[1].SpriteIcon : null;
+		_thirdGearImage.sprite = gears.Count >= 3 ? gears[2].SpriteIcon : null;
 	}
 	
 	// 첫 스테이지는 가리는 패널이 없어야 해서 사용

--- a/Assets/Scripts/GamePlay/InGameGearSlot.cs
+++ b/Assets/Scripts/GamePlay/InGameGearSlot.cs
@@ -1,19 +1,60 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 using UnityEngine.UI;
 
 public class InGameGearSlot : MonoBehaviour {
+	// 진행도 바 이미지
 	[SerializeField] private Image _progressBar;
+	// 반짝할 때 사용할 이미지
+	[SerializeField] Image _shineEffect;
 	
 	private GearBase _gear;
+	private Coroutine _coShowShineEffect;
+	
+	private void SetShineEffectAlpha(float alpha) => _shineEffect.color = new Color(1, 1, 1, alpha);
 	
 	public void Init(GearBase gear) {
 		_gear = gear;
+		// gear가 활성화될 때 생기는 Event에 내 함수 등록해두기
+		if (gear != null) _gear.OnGearActivated.AddListener(ShowShineEffect);
+		// 시작 시에 깜빡임 이펙트는 꺼두기
+		SetShineEffectAlpha(0);
 	}
 
 	private void Update() {
 		if (_gear == null) { _progressBar.fillAmount = 1f;}
 		else {
 			_progressBar.fillAmount = 1f - _gear.GetProgressBarAmount();
+		}
+	}
+	
+	private void ShowShineEffect() {
+		if (_coShowShineEffect != null) { StopCoroutine(_coShowShineEffect); }
+		_coShowShineEffect = StartCoroutine(CoShowShineEffect());
+	}
+	
+	// 잠깐 반짝하고 말도록
+	private IEnumerator CoShowShineEffect() {
+		yield return StartCoroutine(CoShineEffectOn());
+		yield return StartCoroutine(CoShineEffectOff()); 
+	}
+	
+	// 반짝거릴 때 사용
+	private IEnumerator CoShineEffectOn() {
+		float timer = 0f;
+		while (timer < 0.2f) {
+			timer += Time.deltaTime;
+			SetShineEffectAlpha(Mathf.Lerp(0, 1,  timer / 0.1f));
+			yield return null;
+		}
+	}
+	
+	private IEnumerator CoShineEffectOff() {
+		float timer = 0f;
+		while (timer < 0.2f) {
+			timer += Time.deltaTime;
+			SetShineEffectAlpha(Mathf.Lerp(1, 0,  timer / 0.1f));
+			yield return null;
 		}
 	}
 }

--- a/Assets/Scripts/Item/Gear/GearBase.cs
+++ b/Assets/Scripts/Item/Gear/GearBase.cs
@@ -1,6 +1,10 @@
 ﻿using UnityEngine;
+using UnityEngine.Events;
 
 public abstract class GearBase : MonoBehaviour {
 	// 능력 게이지가 얼마나 찼는지 인게임에서 보여줄 때 사용할 함수
 	public abstract float GetProgressBarAmount();
+	
+	// 능력이 발동했을 때 호출될 Event
+	public abstract UnityEvent OnGearActivated { get; } 
 }

--- a/Assets/Scripts/Item/Gear/GearCoinFlower.cs
+++ b/Assets/Scripts/Item/Gear/GearCoinFlower.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 public class GearCoinFlower : GearBase
 {
@@ -12,6 +13,8 @@ public class GearCoinFlower : GearBase
     {
         return 1f;
     }
+
+    public override UnityEvent OnGearActivated { get; } = new();
 
     private void OnEnable()
     {
@@ -28,6 +31,7 @@ public class GearCoinFlower : GearBase
             if (randomW < weight)
             {
                 Instantiate(coinFlowerPrefab,new Vector3(transform.position.x+6f,0f,0f),Quaternion.identity,stageroot.transform);
+                OnGearActivated?.Invoke();
             }
         }
     }

--- a/Assets/Scripts/Item/Gear/GearDrink.cs
+++ b/Assets/Scripts/Item/Gear/GearDrink.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class GearDrink : GearBase
 {
@@ -12,6 +13,8 @@ public class GearDrink : GearBase
     {
         return t / coolTime;
     }
+
+    public override UnityEvent OnGearActivated { get; } = new();
 
     private void OnEnable()
     {
@@ -29,6 +32,7 @@ public class GearDrink : GearBase
         {
             gm.ActivateDash(2f);
             t = 0;
+            OnGearActivated?.Invoke();
         }
 
     }

--- a/Assets/Scripts/Item/Gear/GearMagnet.cs
+++ b/Assets/Scripts/Item/Gear/GearMagnet.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 public class GearMagnet : GearBase
 {
@@ -9,6 +10,9 @@ public class GearMagnet : GearBase
     {
         return 1f;
     }
+
+    // 자석은 별도로 "활성화" 타이밍이 없어서 그냥 킵
+    public override UnityEvent OnGearActivated { get; } = new();
 
     private void Update()
     {


### PR DESCRIPTION
## 작업 브랜치
`feature/107-gear-to-play-ui`

## 작업 요약
준비 화면에서 선택한 유물들이 플레이 화면 UI에 적용되도록 합니다

## 변경 내용
- 준비 화면에서 유물을 선택하면, 플레이 UI에 적용됩니다.
- 유물 효과 발동 시에 깜빡이는 아이콘이 활성화됩니다.
- 이를 위해 GearBase내에 UnityEvent를 추가하고 구현하였습니다.

## 관련 이슈
close #107 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
