### PR TITLE
feature(#112) : Dropzone의 y값 감소

### DIFF
--- a/Assets/Resources/Prefabs/Map/Stage3FarawayOceans/Stage3Prefab.prefab
+++ b/Assets/Resources/Prefabs/Map/Stage3FarawayOceans/Stage3Prefab.prefab
@@ -21397,7 +21397,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 258.2, y: 0}
+  m_AnchoredPosition: {x: 273.66, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!61 &5448269832338188438


### PR DESCRIPTION
## 작업 브랜치
`feature/112-fall-area-adjustment`

## 작업 요약
DropZone의 위치를 아래로 내려 쉽게 낙사 판정이 나지 않도록 했습니다.

## 변경 내용
- Dropzone 위치 변경

## 관련 이슈
close #112 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.