### PR TITLE
feature(#110) : 스테이지 3의 종료지점 BlindPanel 내부로 이동

### DIFF
--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -1988,7 +1988,7 @@ Transform:
   m_GameObject: {fileID: 816586176}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.05, y: -9.57, z: 0}
+  m_LocalPosition: {x: 0.05, y: -16.72, z: 0}
   m_LocalScale: {x: 19.708, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/GameResult/GameResultManager.cs
+++ b/Assets/Scripts/GameResult/GameResultManager.cs
@@ -124,7 +124,7 @@ public class GameResultManager : MonoBehaviour {
 		
 		// 코인 아이콘 표시
 		_coinIcon.gameObject.SetActive(true);
-		yield return new WaitForSeconds(_lerpDuration);
+		yield return new WaitForSeconds(_appearPeriod);
 		
 		// 코인 값 표시
 		float timer = 0f;
@@ -139,7 +139,7 @@ public class GameResultManager : MonoBehaviour {
 		
 		// 젤리 아이콘 표시
 		_scoreIcon.gameObject.SetActive(true);
-		yield return new WaitForSeconds(_lerpDuration);
+		yield return new WaitForSeconds(_appearPeriod);
 		
 		// 젤리 값 표시
 		timer = 0f;


### PR DESCRIPTION
## 작업 브랜치
`feature/110-stage3-endpoint`

## 작업 요약
스테이지 3이 화면이 암전된 후 종료될 수 있도록 종료지점을 암전 박스 안으로 이동시켰습니다.
추가로 게임 결과 씬 스크립트 내부에서 변수값이 잘못 들어가있던 문제를 수정하였습니다.

## 관련 이슈
close #110 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
