### PR TITLE
Feature/116 play obstacle animation

### DIFF
--- a/Assets/Resources/Animations/Obstacle/Obstacle.controller
+++ b/Assets/Resources/Animations/Obstacle/Obstacle.controller
@@ -98,11 +98,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0.75
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1

--- a/Assets/Scripts/Character/CherryBomb.cs
+++ b/Assets/Scripts/Character/CherryBomb.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 public class CherryBomb : MonoBehaviour
 {
+    // 장애물 파괴 시에 사용할 hash값 등록
+    private static readonly int _break = Animator.StringToHash("Break");
     public GameObject effectPrefab;
     public GameObject jellyPrefab;
     public GameObject stageroot;
@@ -35,7 +37,7 @@ public class CherryBomb : MonoBehaviour
             {
                 if(obstacle.CompareTag("Obstacle"))
                 {
-                    Destroy(obstacle.gameObject); // 장애물이 있으면 부숨
+                    obstacle.GetComponent<Animator>().SetTrigger(_break); // 장애물이 있으면 부숨
                 }
 
             }

--- a/Assets/Scripts/Character/CookieCollisionChecker.cs
+++ b/Assets/Scripts/Character/CookieCollisionChecker.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 
 public class CookieCollisionChecker : MonoBehaviour {
+	// 장애물 파괴 시에 사용할 hash값 등록
+	private static readonly int _break = Animator.StringToHash("Break");
 	[SerializeField] private CookieController _cookieController;
 	[SerializeField] private GameManager _gameManager;
 	public CookieController CookieController => _cookieController;
@@ -54,7 +56,7 @@ public class CookieCollisionChecker : MonoBehaviour {
 			if (!_cookieController.CollisionEnabled) { return; }
 			// 대쉬 혹은 거인화 상태라면, 부수고 지나감
 			if (_cookieController.IsDashing || _cookieController.IsGiantMode || _cookieController._isSkill) {
-				Destroy(other.gameObject);
+				other.GetComponent<Animator>().SetTrigger(_break);
 				return;
 			}
 			// 무적 상태라면 데미지 받지 않음


### PR DESCRIPTION
## 작업 브랜치
`feature/116-play-obstacle-animation`

## 변경 내용
- 거대화 시 장애물과 충돌하면 장애물이 파괴되는 애니메이션이 재생되도록 하였습니다.
- 대쉬 중 장애물과 충돌하면 장애물이 파괴되는 애니메이션이 재생되도록 하였습니다.
- 체리 폭탄과 장애물이 충돌하면 장애물이 파괴되는 애니메이션이 재생되도록 하였습니다.
- 장애물에 사용될 AnimationController에서 Exit Time을 제거하였습니다.

## 관련 이슈
close #116 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
