### PR TITLE
Feature/121 result maxscore icon overwrite

### DIFF
--- a/Assets/Resources/DataTables/CookieTable.csv
+++ b/Assets/Resources/DataTables/CookieTable.csv
@@ -1,4 +1,4 @@
 Id,Name,Icon,Desc,Grade,Hp,Type
-Cookie_Pirate,PirateCookieName,PirateCookie,PirateCookieDesc,Rare,100,Pirate
-Cookie_Hero,HeroCookieName,HeroCookie,HeroCookieDesc,Common,100,Hero
-Cookie_Cherry,CherryCookieName,CherryCookie,CherryCookieDesc,Epic,120,Cherry
+Cookie_Pirate,PirateCookieName,PirateCookie,PirateCookieDesc,Rare,50,Pirate
+Cookie_Hero,HeroCookieName,HeroCookie,HeroCookieDesc,Common,50,Hero
+Cookie_Cherry,CherryCookieName,CherryCookie,CherryCookieDesc,Epic,50,Cherry

--- a/Assets/Scenes/GameResultScene.unity
+++ b/Assets/Scenes/GameResultScene.unity
@@ -177,7 +177,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
   m_Padding:
-    m_Left: 50
+    m_Left: 0
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
@@ -243,7 +243,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 600
+  m_PreferredWidth: -1
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -305,7 +305,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 42,425
+  m_text: 999,999
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: e4e7a313a6c10114d963f90d2e0d3e5a, type: 2}
   m_sharedMaterial: {fileID: 9095253403498904313, guid: e4e7a313a6c10114d963f90d2e0d3e5a, type: 2}
@@ -1537,6 +1537,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1559550032}
   - component: {fileID: 1559550033}
+  - component: {fileID: 1559550034}
   m_Layer: 5
   m_Name: StageInfoArea
   m_TagString: Untagged
@@ -1560,9 +1561,9 @@ RectTransform:
   - {fileID: 1154427269}
   m_Father: {fileID: 1887922513}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 339.275, y: -305}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1559550033
@@ -1591,6 +1592,20 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &1559550034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1559550031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ContentSizeFitter
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
 --- !u!1001 &1621489493
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1725,6 +1740,7 @@ GameObject:
   - component: {fileID: 1887922515}
   - component: {fileID: 1887922514}
   - component: {fileID: 1887922516}
+  - component: {fileID: 1887922517}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -1749,9 +1765,9 @@ RectTransform:
   - {fileID: 91391455}
   m_Father: {fileID: 2104119600}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 400, y: -440}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1887922514
@@ -1795,7 +1811,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 600
+  m_PreferredWidth: -1
   m_PreferredHeight: 400
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -1820,6 +1836,20 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &1887922517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1887922512}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ContentSizeFitter
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
 --- !u!1 &1905488231
 GameObject:
   m_ObjectHideFlags: 0
@@ -1873,7 +1903,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 40
+  m_PreferredWidth: 80
   m_PreferredHeight: 50
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -2373,10 +2403,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 91391455}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 574, y: -37}
-  m_SizeDelta: {x: 200, y: 100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2113780757
 MonoBehaviour:
@@ -2428,7 +2458,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.LayoutElement
-  m_IgnoreLayout: 1
+  m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
   m_PreferredWidth: -1

--- a/Assets/Scenes/GameResultScene.unity
+++ b/Assets/Scenes/GameResultScene.unity
@@ -1563,7 +1563,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 339.275, y: -305}
+  m_AnchoredPosition: {x: 324.275, y: -305}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1559550033
@@ -1903,7 +1903,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 80
+  m_PreferredWidth: 50
   m_PreferredHeight: 50
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1

--- a/Assets/Scripts/GameResult/GameResultManager.cs
+++ b/Assets/Scripts/GameResult/GameResultManager.cs
@@ -155,7 +155,7 @@ public class GameResultManager : MonoBehaviour {
 		yield return new WaitForSeconds(_appearPeriod);
 		
 		// Best Score 갱신시에만 표시
-		if (_isMaxScoreRenewed) { _gradeImage.color = new Color(1, 1, 1, 1); }
+		if (_isMaxScoreRenewed) { _bestScoreImage.color = new Color(1, 1, 1, 1); }
 		
 		// 마지막에 결과값 한번 쭉 갱신
 		UpdateAllResults();
@@ -191,6 +191,6 @@ public class GameResultManager : MonoBehaviour {
 		_scoreText.text = _score.ToString("N0");
 		
 		// Best Score 표시 여부 확인해서 표시
-		if (_isMaxScoreRenewed) { _gradeImage.color = new Color(1, 1, 1, 1); }
+		if (_isMaxScoreRenewed) { _bestScoreImage.color = new Color(1, 1, 1, 1); }
 	}
 }

--- a/Assets/Scripts/GameResult/GameResultManager.cs
+++ b/Assets/Scripts/GameResult/GameResultManager.cs
@@ -79,10 +79,11 @@ public class GameResultManager : MonoBehaviour {
 		_coinText.gameObject.SetActive(false);
 		_scoreIcon.gameObject.SetActive(false);
 		_scoreText.gameObject.SetActive(false);
-		_bestScoreImage.gameObject.SetActive(false);
 		
-		// 이미지 텍스트는 비활성화하면 레이아웃이 이상해져서, 투명도 0으로
+		// 결과 아이콘과 최대점수 갱신 아이콘은 비활성화하면 레이아웃이 이상해져서, 투명도 0으로
 		_gradeImage.color = new Color(1, 1, 1, 0);
+		_bestScoreImage.color = new Color(1, 1, 1, 0);
+		
 		// 미리 이미지를 정해둬야 Text위치가 바뀌지 않음
 		_gradeImage.sprite = GetGradeSpriteByStageNum(_stageIdx);
 		
@@ -153,8 +154,8 @@ public class GameResultManager : MonoBehaviour {
 		_scoreText.text = _score.ToString("N0");
 		yield return new WaitForSeconds(_appearPeriod);
 		
-		// Best Score 표시? 혹은 안하기?
-		_bestScoreImage.gameObject.SetActive(_isMaxScoreRenewed);
+		// Best Score 갱신시에만 표시
+		if (_isMaxScoreRenewed) { _gradeImage.color = new Color(1, 1, 1, 1); }
 		
 		// 마지막에 결과값 한번 쭉 갱신
 		UpdateAllResults();
@@ -189,7 +190,7 @@ public class GameResultManager : MonoBehaviour {
 		_scoreText.gameObject.SetActive(true);
 		_scoreText.text = _score.ToString("N0");
 		
-		// Best Score 표시 혹은 안하기
-		_bestScoreImage.gameObject.SetActive(_isMaxScoreRenewed);
+		// Best Score 표시 여부 확인해서 표시
+		if (_isMaxScoreRenewed) { _gradeImage.color = new Color(1, 1, 1, 1); }
 	}
 }


### PR DESCRIPTION
## 작업 브랜치
`feature/121-result-maxscore-icon-overwrite`

## 작업 요약
- 게임 결과 화면에서 최대 점수를 갱신했을 때 이미지가 덮어씌워지는 것을 수정합니다.
- CookieTable 내부 체력값도 수정하였습니다.

## 관련 이슈
close #121 

## 확인 사항
- [x] 로컬에서 빌드 또는 실행을 확인했습니다.
- [x] 변경 범위와 관련된 테스트를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
