### PR TITLE
클릭후 스킵하고 보상 기다리면 갑자기 다시뽑는현상 수정

### DIFF
--- a/Assets/Scripts/Ui/Gacha/BbobgiTitle.cs
+++ b/Assets/Scripts/Ui/Gacha/BbobgiTitle.cs
@@ -167,11 +167,11 @@ public class BbobgiTitle : GenericWindow
                 rewardCheck = false;
                 escdoubleCheck = false;
                 escCheck = true;
+                isClick = false;
                 SkipReward();
                 return;
-
             }
-           
+            isClick = false;
             escdoubleCheck = true;
             effects.transform.localScale = new Vector3(effectscaleMax, effectscaleMax, effectscaleMax);
             rewardCheck = true;


### PR DESCRIPTION
## 작업 브랜치
Feature/Fix-Gacha

## 작업 요약
뽑기 연출스킵후 리워드연출 기다릴떄 다시뽑는현상 수정


## 변경 내용
- 
- 
- 

## 관련 이슈
> 처리한 이슈가 있다면 `close #123` 형식으로 적어주세요.

## 확인 사항
- [ ] 로컬에서 빌드 또는 실행을 확인했습니다.
- [ ] 변경 범위와 관련된 테스트를 확인했습니다.
- [ ] 불필요한 로그, 임시 파일, 디버그 코드를 제거했습니다.
- [ ] Unity 메타 파일 변경 여부를 확인했습니다.

## 참고 자료
> 스크린샷, 영상, 로그, 문서 링크 등 리뷰에 필요한 자료가 있다면 첨부해주세요.
