### PR TITLE
refactor : CookieController 책임 분리 (#129)

### DIFF
--- a/Assets/Resources/Prefabs/Ui/Play/BaseCookie.prefab
+++ b/Assets/Resources/Prefabs/Ui/Play/BaseCookie.prefab
@@ -171,7 +171,7 @@ CapsuleCollider2D:
   m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: -0.08, y: -0.82}
-  m_Size: {x: 1.08, y: 2.36}
+  m_Size: {x: 1.08, y: 2.35}
   m_Direction: 0
 --- !u!114 &8567717157291444384
 MonoBehaviour:
@@ -186,7 +186,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CookieCollisionChecker
   _cookieController: {fileID: 5630293020394366963}
---- !u!1 &4452933684968082351
+  _gameManager: {fileID: 0}
+  _changeStage: 0
+--- !u!1 &4212966327388905811
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -194,46 +196,62 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7222709207348568573}
-  - component: {fileID: 5305658334026297100}
-  - component: {fileID: 7943733558333321254}
-  - component: {fileID: 2615641987897293069}
-  - component: {fileID: 2087361772635488321}
-  - component: {fileID: 5630293020394366963}
-  - component: {fileID: 7126042939000283837}
+  - component: {fileID: 8327118611032423940}
+  - component: {fileID: 8999173042583954117}
+  - component: {fileID: 6200421209569298278}
+  - component: {fileID: 4740290898441428290}
   m_Layer: 0
-  m_Name: BaseCookie
+  m_Name: CookieVisual
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7222709207348568573
+--- !u!4 &8327118611032423940
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4452933684968082351}
+  m_GameObject: {fileID: 4212966327388905811}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6, y: -3.91, z: 0}
-  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 574136981216230339}
-  - {fileID: 5208596194788919393}
-  - {fileID: 9197689710625806770}
-  m_Father: {fileID: 0}
+  m_Children: []
+  m_Father: {fileID: 7222709207348568573}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5305658334026297100
+--- !u!95 &8999173042583954117
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4212966327388905811}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!212 &6200421209569298278
 SpriteRenderer:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4452933684968082351}
+  m_GameObject: {fileID: 4212966327388905811}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -271,20 +289,79 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: -966681783
-  m_SortingLayer: 2
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 6805693047356623700, guid: a0489b6321f71d04c8ed72af37c2dd7c, type: 3}
+  m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.77, y: 2}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_SpriteSortPoint: 0
+--- !u!114 &4740290898441428290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4212966327388905811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7bd354956744219b541c1d36329e22b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieRenderer
+--- !u!1 &4452933684968082351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7222709207348568573}
+  - component: {fileID: 7943733558333321254}
+  - component: {fileID: 2615641987897293069}
+  - component: {fileID: 2087361772635488321}
+  - component: {fileID: 5630293020394366963}
+  - component: {fileID: 6773060119075874205}
+  - component: {fileID: 7659667361548828086}
+  - component: {fileID: 9077476192347511553}
+  - component: {fileID: 1433624404273702603}
+  - component: {fileID: 9096583113551313584}
+  - component: {fileID: 6401933373911461714}
+  - component: {fileID: 7126042939000283837}
+  m_Layer: 0
+  m_Name: BaseCookie
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7222709207348568573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6, y: -3.91, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8327118611032423940}
+  - {fileID: 574136981216230339}
+  - {fileID: 5208596194788919393}
+  - {fileID: 9197689710625806770}
+  - {fileID: 111160477642506979}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &7943733558333321254
 Animator:
   serializedVersion: 7
@@ -293,7 +370,7 @@ Animator:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4452933684968082351}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Avatar: {fileID: 0}
   m_Controller: {fileID: 0}
   m_CullingMode: 0
@@ -322,7 +399,7 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDamping: 0
   m_AngularDamping: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 8
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -392,9 +469,73 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d88e76bf8a747669ccc0afc14b92bed, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CookieController
+  _isSkill: 0
+  roof: {fileID: 0}
+  _abilityProgressBar: {fileID: 8606422125004181002}
+  _fallAlertPanel: {fileID: 0}
+  _cookieRenderer: {fileID: 4740290898441428290}
+--- !u!114 &6773060119075874205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8e1ff14904e2e24098c825474021fd6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ChargeJellyBatch
+  stateObject: {fileID: 0}
+  chargeJellyPrefab: {fileID: 1637299784096980318, guid: 82b50d755553dc846bfc0f7ed2ffec63, type: 3}
+  distanceThreshold: 20
+--- !u!114 &7659667361548828086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 807421bf0fb4c7e4ea95e2d051c2e4aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieGearController
+  gearPrefabParent: {fileID: 0}
+--- !u!114 &9077476192347511553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ff69fd05f23e764b890da765b0baa50, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieHealthController
+  _hpBar: {fileID: 0}
+  _additionalHpBar: {fileID: 0}
+  _healthBarShine: {fileID: 0}
   OnTakeDamage:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1433624404273702603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 445836af562c90745898acfbf1f1a570, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieInputController
+  JumpButton: {fileID: 0}
+  SlideButton: {fileID: 0}
+  _jumpKey: 32
+  _slideKey: 306
   OnJumpKeyDown:
     m_PersistentCalls:
       m_Calls: []
@@ -413,17 +554,30 @@ MonoBehaviour:
   WhileSlideKeyPressed:
     m_PersistentCalls:
       m_Calls: []
-  _hpBar: {fileID: 0}
-  _additionalHpBar: {fileID: 0}
-  _healthBarShine: {fileID: 0}
-  _abilityProgressBar: {fileID: 8606422125004181002}
-  JumpButton: {fileID: 0}
-  SlideButton: {fileID: 0}
-  _jumpKey: 32
-  _slideKey: 306
-  _jumpForce: 25
-  _gravityScale: 10
-  _healthReduceSpeed: 2
+--- !u!114 &9096583113551313584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3db1b95edaed0dc469a223887d1f347e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieMovementController
+--- !u!114 &6401933373911461714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4452933684968082351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 290b9fbd9cf74a548b2c9abb7a9490e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CookieSizeController
   _collisionCollider: {fileID: 8567717157291444384}
 --- !u!82 &7126042939000283837
 AudioSource:
@@ -588,7 +742,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0.59}
+  m_Offset: {x: 0, y: 0.11}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -598,7 +752,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 0.14, y: 0.31}
   m_EdgeRadius: 0
 --- !u!1 &5300641201557095212
 GameObject:
@@ -675,6 +829,37 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5311825843120459025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 111160477642506979}
+  m_Layer: 0
+  m_Name: GearSlot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &111160477642506979
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5311825843120459025}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 0.6666667}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7222709207348568573}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6422571429211417960
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayScene.unity
+++ b/Assets/Scenes/PlayScene.unity
@@ -935,133 +935,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 403513910}
   m_CullTransparentMesh: 1
---- !u!1 &487568987
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 487568989}
-  - component: {fileID: 487568988}
-  - component: {fileID: 487568990}
-  - component: {fileID: 487568991}
-  m_Layer: 0
-  m_Name: CookieVisual
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!95 &487568988
-Animator:
-  serializedVersion: 7
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 487568987}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!4 &487568989
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 487568987}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1089295749770407401}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &487568990
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 487568987}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_SpriteSortPoint: 0
---- !u!114 &487568991
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 487568987}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7bd354956744219b541c1d36329e22b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::CookieRenderer
 --- !u!1 &549349323
 GameObject:
   m_ObjectHideFlags: 0
@@ -1599,37 +1472,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::InGameGearSlot
   _progressBar: {fileID: 1503560012}
   _shineEffect: {fileID: 1237831493}
---- !u!1 &702772407
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 702772408}
-  m_Layer: 0
-  m_Name: GearSlot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &702772408
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 702772407}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 0.6666667}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1089295749770407401}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &710067087
 GameObject:
   m_ObjectHideFlags: 0
@@ -5216,7 +5058,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
   m_PrefabInstance: {fileID: 1089295749770407398}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089295749770407399}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5d88e76bf8a747669ccc0afc14b92bed, type: 3}
@@ -5235,86 +5077,30 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2514233627556925859, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Size.y
-      value: 2.35
-      objectReference: {fileID: 0}
-    - target: {fileID: 2615641987897293069, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_GravityScale
-      value: 8
-      objectReference: {fileID: 0}
+    - target: {fileID: 1433624404273702603, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: JumpButton
+      value: 
+      objectReference: {fileID: 969491471}
+    - target: {fileID: 1433624404273702603, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: SlideButton
+      value: 
+      objectReference: {fileID: 204089303}
     - target: {fileID: 4452933684968082351, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: m_Name
       value: BaseCookie
-      objectReference: {fileID: 0}
-    - target: {fileID: 5305658334026297100, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Enabled
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: roof
       value: 
       objectReference: {fileID: 2134716886}
     - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _hpBar
-      value: 
-      objectReference: {fileID: 65928756}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _animator
-      value: 
-      objectReference: {fileID: 487568988}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: JumpButton
-      value: 
-      objectReference: {fileID: 969491471}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: SlideButton
-      value: 
-      objectReference: {fileID: 204089303}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _gravityScale
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _cookieRenderer
-      value: 
-      objectReference: {fileID: 487568991}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: _fallAlertPanel
       value: 
       objectReference: {fileID: 686019903}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _healthBarShine
+    - target: {fileID: 6773060119075874205, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: stateObject
       value: 
-      objectReference: {fileID: 730792933}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _spriteRenderer
-      value: 
-      objectReference: {fileID: 487568990}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _additionalHpBar
-      value: 
-      objectReference: {fileID: 403513912}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: gearPrefabParent
-      value: 
-      objectReference: {fileID: 702772408}
-    - target: {fileID: 5630293020394366963, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: _linearVelocityMax
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Size.x
-      value: 0.14
-      objectReference: {fileID: 0}
-    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Size.y
-      value: 0.31
-      objectReference: {fileID: 0}
-    - target: {fileID: 6777470905179820843, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Offset.y
-      value: 0.11
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1464115433}
     - target: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: m_LocalPosition.x
       value: -6
@@ -5355,51 +5141,34 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7943733558333321254, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
+    - target: {fileID: 7659667361548828086, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: gearPrefabParent
+      value: 
+      objectReference: {fileID: 1089295749770407399}
     - target: {fileID: 8567717157291444384, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
       propertyPath: _gameManager
       value: 
       objectReference: {fileID: 1874526744}
+    - target: {fileID: 9077476192347511553, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: _hpBar
+      value: 
+      objectReference: {fileID: 65928756}
+    - target: {fileID: 9077476192347511553, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: _healthBarShine
+      value: 
+      objectReference: {fileID: 730792933}
+    - target: {fileID: 9077476192347511553, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+      propertyPath: _additionalHpBar
+      value: 
+      objectReference: {fileID: 403513912}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      insertIndex: 0
-      addedObject: {fileID: 487568989}
-    - targetCorrespondingSourceObject: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 702772408}
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 4452933684968082351, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1089295749770407400}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
---- !u!1 &1089295749770407399 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4452933684968082351, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
-  m_PrefabInstance: {fileID: 1089295749770407398}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1089295749770407400
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1089295749770407399}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b8e1ff14904e2e24098c825474021fd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ChargeJellyBatch
-  stateObject: {fileID: 1464115433}
-  chargeJellyPrefab: {fileID: 1637299784096980318, guid: 82b50d755553dc846bfc0f7ed2ffec63, type: 3}
-  distanceThreshold: 20
---- !u!4 &1089295749770407401 stripped
+--- !u!4 &1089295749770407399 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 7222709207348568573, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
+  m_CorrespondingSourceObject: {fileID: 111160477642506979, guid: 9f088c791e50a84409cf627cd4806495, type: 3}
   m_PrefabInstance: {fileID: 1089295749770407398}
   m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807

--- a/Assets/Scripts/Character/CookieCollisionChecker.cs
+++ b/Assets/Scripts/Character/CookieCollisionChecker.cs
@@ -18,7 +18,7 @@ public class CookieCollisionChecker : MonoBehaviour
     private readonly float _standingColliderXOffset = -0.08f;
     private readonly float _standingColliderXSize = 1.08f;
     private readonly float _standingColliderYOffset = -0.82f;
-    private readonly float _standingColliderYSize = 2.36f;
+    private readonly float _standingColliderYSize = 2.35f;
 
     private readonly float _slidingColliderXOffset = 0f;
     private readonly float _slidingColliderXSize = 1.39f;
@@ -49,7 +49,7 @@ public class CookieCollisionChecker : MonoBehaviour
 
     private void SetStandingOffset()
     {
-        _collider2D.offset = new Vector2(_standingColliderXOffset, _slidingColliderYOffset);
+        _collider2D.offset = new Vector2(_standingColliderXOffset, _standingColliderYOffset);
     }
 
     public void SetSlidingSize()
@@ -59,7 +59,7 @@ public class CookieCollisionChecker : MonoBehaviour
 
     public void SetStandingSize()
     {
-        _collider2D.size = new Vector2(_standingColliderXSize, _slidingColliderYSize);
+        _collider2D.size = new Vector2(_standingColliderXSize, _standingColliderYSize);
     }
 
     private void OnTriggerEnter2D(Collider2D other)

--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -1,125 +1,61 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
-// 모든 쿠키가 베이스로 사용할 클래스입니다.
-// 쿠키에는 필수적으로 Rigidbody2D, Animator, BoxCollider2D가 붙어있어야 합니다.
 [RequireComponent(typeof(Rigidbody2D), typeof(Animator), typeof(BoxCollider2D))]
 public class CookieController : MonoBehaviour
 {
-    // UI가 표현 가능한 최대체력을 정의
-    private readonly float UiMaxHp = 100f;
+    // 능력 사용 중일 때 등 점프 불가능하게 하고 싶을 때 사용
+    public bool JumpEnabled { get; set; } = true;
 
-    // 체력 세팅 관련 변수
-    private float MaxHp { get; set; }
-    private readonly float MaxAdditionalHp = 100f;
-    private float _currentHp;
-    private float _additionalHp;
+    // 같은 이유로 슬라이딩 불가능하게 하고 싶을 때 사용
+    public bool SlideEnabled { get; set; } = true;
 
-    // 무적, 능력 관련 변수
-    private readonly float _godModeDurationAfterHit = 2f;
-    private bool _isGodMode = false;
-    private bool _isDashing = false;
-    private bool _isGiantMode = false;
+    // 체력 줄지 않게 하고 싶을 때 사용
+    public bool CollisionEnabled { get; set; } = true;
+
+    // 체력 회복되지 않게 하고 싶을 때 사용
+    public bool HealEnabled { get; set; } = true;
+
     public bool _isSkill = false; // 스킬 : 무적, 충돌이 같이 들어가야하는 쿠키용
 
-    // 데미지 입을 시 특정 행동을 하는 캐릭터들이 사용하기 위한 이벤트
-    [HideInInspector]
-    public UnityEvent OnTakeDamage;
-
-    // 이벤트 종류별로 모두 생성 (점프키 누르기, 떼기, 누르고있기, 슬라이드 누르기, 떼기, 누르고있기)
-    [HideInInspector]
-    public UnityEvent OnJumpKeyDown;
-
-    [HideInInspector]
-    public UnityEvent OnJumpKeyUp;
-
-    [HideInInspector]
-    public UnityEvent WhileJumpKeyPressed;
-
-    [HideInInspector]
-    public UnityEvent OnSlideKeyDown;
-
-    [HideInInspector]
-    public UnityEvent OnSlideKeyUp;
-
-    [HideInInspector]
-    public UnityEvent WhileSlideKeyPressed;
-
-    [Header("=== 체력바 관련 Image ===")]
-    [SerializeField]
-    private Image _hpBar;
-
-    [SerializeField]
-    private Image _additionalHpBar;
-
-    [SerializeField]
-    private Image _healthBarShine;
+    [Header("=== 비행 쿠키 전용 천장 ===")]
+    public GameObject roof;
 
     [Header("=== 능력치 표시 바 ===")]
     [SerializeField]
     private Image _abilityProgressBar;
 
-    [Header("=== 점프, 슬라이드 버튼 ===")]
-    [SerializeField]
-    public JumpButton JumpButton;
-
-    [SerializeField]
-    public SlideButton SlideButton;
-
-    [Header("=== 단축키 ===")]
-    [SerializeField]
-    private KeyCode _jumpKey = KeyCode.Space;
-
-    [SerializeField]
-    private KeyCode _slideKey = KeyCode.LeftControl;
-
-    [Header("=== 실제 충돌 처리할 캡슐 ===")]
-    [SerializeField]
-    private CookieCollisionChecker _collisionCollider;
-
     [Header("=== 떨어졌을때 메세지 출력할 Panel ===")]
     [SerializeField]
     private GameObject _fallAlertPanel;
-
-    [Header("=== 비행 쿠키 전용 천장 ===")]
-    public GameObject roof;
-
-    [Header("=== 보물 프리팹 생성 ===")]
-    public Transform gearPrefabParent;
 
     [Header("=== 쿠키 애니메이션을 재생할 GameObject ===")]
     [SerializeField]
     private CookieRenderer _cookieRenderer;
 
-    // 점프 관련 변수
-    private readonly float _jumpForce = 25f;
-    private readonly float _gravityScale = 8f;
-    private readonly float _healthReduceSpeed = 2f;
-    private readonly float _linearVelocityMax = 22f;
-    public float GravityScale => _gravityScale;
-
     // 사망 후 몇 초 있다 엔딩화면으로 넘어갈지
     private readonly float _latencyAfterDeath = 1.5f;
 
-    // 점프하자마자 Ground와 착지 판정 생겨서 3단 점프 되는 문제 해결을 위함
-    private float _ignoreGroundTimer;
-    private readonly float _ignoreGroundDuration = 0.1f;
+    private bool _isDashing;
+    private bool _isGiantMode;
 
     // 붙어있는 Component 목록
-    private Rigidbody2D _rigidBody;
     private BoxCollider2D _collider;
     private CookieBehavior _cookieBehavior;
     private GameManager _gameManager;
-    private CookieState _state;
     private Animator _animator;
-    private SpriteRenderer _spriteRenderer;
+
+    // 서브 컴포넌트
+    private CookieHealthController _healthController;
+    private CookieInputController _inputController;
+    private CookieSizeController _sizeController;
+    private CookieGearController _gearController;
+    private CookieMovementController _movementController;
+
     public Animator Animator => _animator;
     public BoxCollider2D Collider => _collider;
-    public CookieCollisionChecker CollisionCollider => _collisionCollider;
-    public bool IsGodMode => _isGodMode;
 
     public bool IsGiantMode
     {
@@ -133,12 +69,12 @@ public class CookieController : MonoBehaviour
         set
         {
             // 대쉬 먹게 되었을 때, 뛰는 상태면 Dash로 애니메이션 바꿔주기
-            if (value && _state == CookieState.Run)
+            if (value && _movementController.CurrentState == CookieState.Run)
             {
                 _cookieBehavior.StartDashAnimation();
             }
             // 대쉬 끝날 때, 뛰는 상태면 Run으로 애니메이션 변경
-            else if (!value && _state == CookieState.Run)
+            else if (!value && _movementController.CurrentState == CookieState.Run)
             {
                 _cookieBehavior.StartRunAnimation();
             }
@@ -146,65 +82,71 @@ public class CookieController : MonoBehaviour
         }
     }
 
-    private bool _jumpRequested;
+    // === Health forwarding ===
+    public float CurrentHp => _healthController.CurrentHp;
+    public float AdditionalHp => _healthController.AdditionalHp;
+    public bool IsGodMode => _healthController.IsGodMode;
+    public UnityEvent OnTakeDamage => _healthController.OnTakeDamage;
 
-    // 능력 사용 중일 때 등 점프 불가능하게 하고 싶을 때 사용
-    public bool JumpEnabled { get; set; } = true;
+    public void TakeDamage(float amount) => _healthController.TakeDamage(amount);
 
-    // 같은 이유로 슬라이딩 불가능하게 하고 싶을 때 사용
-    public bool SlideEnabled { get; set; } = true;
+    public void RecoverHp(float amount) => _healthController.RecoverHp(amount);
 
-    // 체력 줄지 않게 하고 싶을 때 사용
-    public bool CollisionEnabled { get; set; } = true;
+    public void GetAdditionalHealth(float amount) => _healthController.GetAdditionalHealth(amount);
 
-    // 체력 회복되지 않게 하고 싶을 때 사용
-    public bool HealEnabled { get; set; } = true;
+    public void EnableGodMode(float duration) => _healthController.EnableGodMode(duration);
 
-    //private readonly float _standingYPos = -2.735f;
-    private readonly float _slidingYDiff = -0.425f;
+    // === Input forwarding ===
+    public UnityEvent OnJumpKeyDown => _inputController.OnJumpKeyDown;
+    public UnityEvent OnJumpKeyUp => _inputController.OnJumpKeyUp;
+    public UnityEvent WhileJumpKeyPressed => _inputController.WhileJumpKeyPressed;
+    public UnityEvent OnSlideKeyDown => _inputController.OnSlideKeyDown;
+    public UnityEvent OnSlideKeyUp => _inputController.OnSlideKeyUp;
+    public UnityEvent WhileSlideKeyPressed => _inputController.WhileSlideKeyPressed;
 
-    private readonly float _standingColliderYOffset = -0.21f;
-    private readonly float _standingColliderYSize = 1.32f;
-    private readonly float _slidingColliderYOffset = -0.21f;
-    private readonly float _slidingColliderYSize = 0.7f;
+    // === Size forwarding ===
+    public CookieCollisionChecker CollisionCollider => _sizeController.CollisionCollider;
 
-    private Coroutine _coGodMode;
+    public void SetSlidingCollider() => _sizeController.SetSlidingCollider();
 
-    // 체력 관련 값 세팅시에는, Clamping해서 범위 넘어가지 않도록 함
-    public float CurrentHp
-    {
-        get => _currentHp;
-        private set => _currentHp = Mathf.Clamp(value, 0, MaxHp);
-    }
-    public float AdditionalHp
-    {
-        get => _additionalHp;
-        private set => _additionalHp = Mathf.Clamp(value, 0, MaxAdditionalHp);
-    }
+    public void SetStandingCollider() => _sizeController.SetStandingCollider();
 
-    private float UiHpPercent => CurrentHp / UiMaxHp;
-    private float AdditionalHpPercent => AdditionalHp / MaxAdditionalHp;
+    public void SetSlidingPosition() => _sizeController.SetSlidingPosition();
+
+    public void SetStandingPosition() => _sizeController.SetStandingPosition();
+
+    // === Movement forwarding ===
+    public void RequestJump() => _movementController.RequestJump();
+
+    public void RequestSlidingStart() => _movementController.RequestSlidingStart();
+
+    public void RequestSlidingEnd() => _movementController.RequestSlidingEnd();
+
+    public float GravityScale => _movementController.GravityScale;
 
     public void Init(CookieData data, GameManager gameManager)
     {
         _gameManager = gameManager;
 
-        MaxHp = data.Hp;
-        CurrentHp = MaxHp;
+        _collider = GetComponent<BoxCollider2D>();
+        _animator = _cookieRenderer.Animator;
+
+        _healthController = GetComponent<CookieHealthController>();
+        _inputController = GetComponent<CookieInputController>();
+        _sizeController = GetComponent<CookieSizeController>();
+        _gearController = GetComponent<CookieGearController>();
+        _movementController = GetComponent<CookieMovementController>();
+
+        _healthController.Init(data.Hp, _cookieRenderer.SpriteRenderer);
+        _inputController.Init(_gameManager);
 
         // Factory 이용해서 data에 맞는 Behavior 붙이기
         CookieBehaviorFactory.AddBehavior(gameObject, data);
-
-        // 보물 장착
-        SetGear();
-
-        _rigidBody = GetComponent<Rigidbody2D>();
         _cookieBehavior = GetComponent<CookieBehavior>();
-        _collider = GetComponent<BoxCollider2D>();
-        _animator = _cookieRenderer.Animator;
-        _spriteRenderer = _cookieRenderer.SpriteRenderer;
 
-        _rigidBody.gravityScale = _gravityScale;
+        _movementController.Init(_cookieBehavior, _sizeController, this);
+
+        _gearController.SetGear(gameManager);
 
         _cookieBehavior.Init(this);
         _animator.runtimeAnimatorController = data.AnimatorController;
@@ -219,22 +161,14 @@ public class CookieController : MonoBehaviour
             _cookieBehavior.StartRunAnimation();
         }
 
-        // 점프 및 슬라이드 버튼의 동작을 키와 동기화
-        JumpButton.OnButtonDown.AddListener(() => OnJumpKeyDown?.Invoke());
-        JumpButton.OnButtonUp.AddListener(() => OnJumpKeyUp?.Invoke());
-        JumpButton.WhileButtonPressed.AddListener(() => WhileJumpKeyPressed?.Invoke());
-        SlideButton.OnButtonDown.AddListener(() => OnSlideKeyDown?.Invoke());
-        SlideButton.OnButtonUp.AddListener(() => OnSlideKeyUp?.Invoke());
-        SlideButton.WhileButtonPressed.AddListener(() => WhileSlideKeyPressed?.Invoke());
-
-        // 처음엔 점프 눌렀을 때 RequestJump, 슬라이드 누르고 뗄 때 Start, End만 넣음
+        // 점프 및 슬라이드 이벤트에 실제 동작 바인딩
         OnJumpKeyDown.AddListener(RequestJump);
         OnSlideKeyDown.AddListener(RequestSlidingStart);
         OnSlideKeyUp.AddListener(RequestSlidingEnd);
         // 슬라이드 누르고 있으면 땅에 내리자마자 슬라이딩
         WhileSlideKeyPressed.AddListener(() =>
         {
-            if (_state == CookieState.Run)
+            if (_movementController.CurrentState == CookieState.Run)
             {
                 RequestSlidingStart();
             }
@@ -250,95 +184,30 @@ public class CookieController : MonoBehaviour
         _cookieRenderer.SetSpriteLocation(data);
     }
 
-    // 체력 감소
-    public void TakeDamage(float amount)
+    private void Update()
     {
-        // 무적 상태일 땐 데미지 없음
-        if (_isGodMode)
+        // 사망 체크 후 각 서브 컴포넌트 코디네이션
+        if (_cookieBehavior.DeathCheck() && _movementController.CurrentState != CookieState.Death)
         {
+            _movementController.MarkDead();
+            _gameManager.GameEndFlag = true;
+            _healthController.StopGodMode();
+            _sizeController.SetSlidingPosition();
+            _sizeController.SetSlidingCollider();
+            _cookieBehavior.StartDeathAnimation();
+            StartCoroutine(CoEndGame());
             return;
         }
-        // 추가체력이 있다면, 그것부터 감소
-        if (_additionalHp > 0)
+
+        // ProgressBar 사용한다면, 현재 진행도 값으로 fillAmount 수정
+        if (_cookieBehavior.UseAbilityProgressBar)
         {
-            float reducedAmount = Mathf.Clamp(amount, 0, _additionalHp);
-            AdditionalHp -= reducedAmount;
-            amount -= reducedAmount;
+            _abilityProgressBar.fillAmount = _cookieBehavior.GetProgressbarAmount();
         }
-
-        CurrentHp -= amount;
-
-        // 부딫혔을 때 이벤트 활성화
-        OnTakeDamage?.Invoke();
-        // 무적 상태 활성화
-        EnableGodMode(_godModeDurationAfterHit);
-    }
-
-    public void EnableGodMode(float duration)
-    {
-        if (_coGodMode != null)
-            StopCoroutine(_coGodMode);
-        _coGodMode = StartCoroutine(CoGodMode(duration));
-    }
-
-    // 실제 무적모드 효과 연출 및 무적 적용
-    private IEnumerator CoGodMode(float duration)
-    {
-        _isGodMode = true;
-        float godModeTimer = 0f;
-
-        while (godModeTimer <= duration)
-        {
-            godModeTimer += Time.deltaTime;
-            if ((int)(godModeTimer / 0.1) % 2 == 0)
-            {
-                _spriteRenderer.enabled = false;
-            }
-            else
-            {
-                _spriteRenderer.enabled = true;
-            }
-
-            yield return null;
-        }
-
-        _spriteRenderer.enabled = true;
-        _isGodMode = false;
-    }
-
-    // 체력 증가
-    public void RecoverHp(float amount)
-    {
-        CurrentHp += amount;
-    }
-
-    public void GetAdditionalHealth(float amount)
-    {
-        AdditionalHp += amount;
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        // 땅에 닿으면 점프 초기화
-        if (
-            other.CompareTag(Tags.Ground)
-            && (_state == CookieState.Jump || _state == CookieState.DoubleJump)
-            && _ignoreGroundTimer >= _ignoreGroundDuration
-        )
-        {
-            _state = CookieState.Run;
-
-            // 대쉬중이라면 대쉬모션, 아니라면 일반모션
-            if (IsDashing)
-            {
-                _cookieBehavior.StartDashAnimation();
-            }
-            else
-            {
-                _cookieBehavior.StartRunAnimation();
-            }
-        }
-
         // 바닥으로 떨어지면 게임 종료 처리
         if (other.CompareTag(Tags.Drop))
         {
@@ -348,247 +217,9 @@ public class CookieController : MonoBehaviour
         }
     }
 
-    private void Update()
-    {
-        // 체력 조금씩 줄이기. 추가체력 있으면 추가체력부터
-        if (AdditionalHp > 0)
-        {
-            AdditionalHp -= _healthReduceSpeed * Time.deltaTime;
-        }
-        else
-        {
-            CurrentHp -= _healthReduceSpeed * Time.deltaTime;
-        }
-
-        // 죽었는지 체크해서 게임 종료 알림 및 RigidBody 해제
-        if (_cookieBehavior.DeathCheck() && _state != CookieState.Death)
-        {
-            _state = CookieState.Death;
-            _gameManager.GameEndFlag = true;
-            _rigidBody.simulated = false;
-
-            // 사망 시에 무적상태였을 수 있으니, 무적상태 연출 해제
-            StopCoroutine(_coGodMode);
-            _spriteRenderer.enabled = true;
-
-            // 죽었을 때 충돌 판정 조정해서 죽는 모션 자연스럽게
-            SetSlidingPosition();
-            SetSlidingCollider();
-            _cookieBehavior.StartDeathAnimation();
-
-            StartCoroutine(CoEndGame());
-
-            return;
-        }
-
-        // UI도 줄이고, 위치 설정
-        _hpBar.fillAmount = UiHpPercent;
-        // 추가체력 위치 설정시에는 체력바 줄어든 값에 맞춰서 배치
-        _additionalHpBar.rectTransform.anchoredPosition = new Vector2(
-            _hpBar.rectTransform.anchoredPosition.x
-                + _hpBar.rectTransform.sizeDelta.x * UiHpPercent,
-            _additionalHpBar.rectTransform.anchoredPosition.y
-        );
-        _additionalHpBar.fillAmount = AdditionalHpPercent;
-        // 추가체력 위치까지 고려해서 Shine 배치
-        _healthBarShine.rectTransform.anchoredPosition = new Vector2(
-            _additionalHpBar.rectTransform.anchoredPosition.x
-                + _additionalHpBar.rectTransform.sizeDelta.x * AdditionalHpPercent
-                - 20,
-            _healthBarShine.rectTransform.anchoredPosition.y
-        );
-        // ProgressBar 사용한다면, 현재 진행도 값으로 ProgressbarAmount 수정
-        if (_cookieBehavior.UseAbilityProgressBar)
-        {
-            _abilityProgressBar.fillAmount = _cookieBehavior.GetProgressbarAmount();
-        }
-
-        // Update에서는 점프애 관련하여 요청했는지 확인만, 물리 처리는 FixedUpdate에서 수행
-        if (Input.GetKeyDown(_jumpKey))
-        {
-            OnJumpKeyDown?.Invoke();
-        }
-        if (Input.GetKeyUp(_jumpKey))
-        {
-            OnJumpKeyUp?.Invoke();
-        }
-        if (Input.GetKey(_jumpKey))
-        {
-            WhileJumpKeyPressed?.Invoke();
-        }
-        // 슬라이드 키 누르면 슬라이드 시작
-        if (Input.GetKeyDown(_slideKey))
-        {
-            OnSlideKeyDown?.Invoke();
-        }
-        // 슬라이드 키 떼면 슬라이드 종료
-        if (Input.GetKeyUp(_slideKey))
-        {
-            OnSlideKeyUp?.Invoke();
-        }
-        if (Input.GetKey(_slideKey))
-        {
-            WhileSlideKeyPressed?.Invoke();
-        }
-
-        // 임시. A키 누르면 임시 체력 생김
-        if (Input.GetKeyDown(KeyCode.A))
-        {
-            GetAdditionalHealth(10);
-            _gameManager.ActivateDash(5f);
-        }
-    }
-
-    private void FixedUpdate()
-    {
-        _ignoreGroundTimer += Time.deltaTime;
-
-        // 점프 요청되었다면 점프
-        if (_jumpRequested && JumpEnabled && _state != CookieState.Death)
-        {
-            if (_state == CookieState.Run || _state == CookieState.Slide)
-            {
-                _ignoreGroundTimer = 0f;
-                _state = CookieState.Jump;
-                _cookieBehavior.StartJumpAnimation();
-
-                // 점프하면 포지션 값 초기화
-                SetStandingPosition();
-                SetStandingCollider();
-
-                _rigidBody.linearVelocity = new Vector2(0, _jumpForce);
-            }
-            else if (_state == CookieState.Jump)
-            {
-                _state = CookieState.DoubleJump;
-                _cookieBehavior.StartDoubleJumpAnimation();
-
-                _rigidBody.linearVelocity = new Vector2(0, _jumpForce);
-            }
-        }
-        _jumpRequested = false;
-
-        // 만약 스피드가 제한 속도 이상이면, 그 아래로 잘라줘야 함(중력 영향 줄이기)
-        var temp = _rigidBody.linearVelocity;
-        temp.y = Mathf.Clamp(temp.y, -_linearVelocityMax, _linearVelocityMax);
-        _rigidBody.linearVelocity = temp;
-    }
-
-    public void RequestJump()
-    {
-        _jumpRequested = true;
-    }
-
-    public void RequestSlidingStart()
-    {
-        // 점프나 더블점프중엔 슬라이드 불가능
-        if (
-            _state == CookieState.Jump
-            || _state == CookieState.DoubleJump
-            || _state == CookieState.Death
-        )
-        {
-            return;
-        }
-        if (!SlideEnabled)
-        {
-            return;
-        }
-        _state = CookieState.Slide;
-
-        SetSlidingPosition();
-        SetSlidingCollider();
-        _cookieBehavior.StartSlidingAnimation();
-    }
-
-    public void RequestSlidingEnd()
-    {
-        // 슬라이딩 중일 때만 슬라이딩 종료 가능
-        if (_state != CookieState.Slide)
-        {
-            return;
-        }
-
-        _state = CookieState.Run;
-
-        SetStandingPosition();
-        SetStandingCollider();
-        _cookieBehavior.StartRunAnimation();
-    }
-
-    // 슬라이딩 시에 위치 자연스럽게 변경
-    public void SetSlidingPosition()
-    {
-        _collisionCollider.SetSlidingPos();
-        transform.position = new Vector3(
-            transform.position.x,
-            transform.position.y + _slidingYDiff,
-            transform.position.z
-        );
-    }
-
-    // 위치 원래대로
-    public void SetStandingPosition()
-    {
-        _collisionCollider.SetStandingPos();
-        transform.position = new Vector3(
-            transform.position.x,
-            transform.position.y - _slidingYDiff,
-            transform.position.z
-        );
-    }
-
-    // 슬라이딩 시에 충돌 박스 크기 자연스럽게 변경
-    public void SetSlidingCollider()
-    {
-        _collider.offset = new Vector2(_collider.offset.x, _slidingColliderYOffset);
-        _collider.size = new Vector2(_collider.size.x, _slidingColliderYSize);
-    }
-
-    // 충돌 박스 크기 원래대로
-    public void SetStandingCollider()
-    {
-        _collider.offset = new Vector2(_collider.offset.x, _standingColliderYOffset);
-        _collider.size = new Vector2(_collider.size.x, _standingColliderYSize);
-    }
-
     private IEnumerator CoEndGame()
     {
         yield return new WaitForSeconds(_latencyAfterDeath);
         _gameManager.EndGame();
-    }
-
-    private void SetGear()
-    {
-        string[] gearIds = SaveLoadManager.Data.currentGear;
-        List<GearBase> gears = new List<GearBase>();
-        List<GearData> gearDatas = new List<GearData>();
-
-        foreach (string id in gearIds)
-        {
-            if (string.IsNullOrEmpty(id))
-                continue;
-
-            // 테이블에서 ID에 해당하는 데이터(SO) 가져오기
-            // 추하게 들고오긴 했음..
-            var gearData = DataTableManager.GearTable.Get(id);
-            var gearPrefab = GameObject
-                .FindGameObjectWithTag("SceneManager")
-                .GetComponent<GachaManager>()
-                .itemList.Find(g => g.itemId == id)
-                .GearPrefab;
-            gearDatas.Add(gearData);
-
-            if (gearData != null && gearPrefab != null)
-            {
-                GameObject gearObj = Instantiate(gearPrefab, gearPrefabParent);
-                gears.Add(gearObj.GetComponent<GearBase>());
-                Debug.Log($"{id} 보물이 {gearPrefabParent.name} 아래에 생성되었습니다.");
-            }
-        }
-
-        // UI에도 유물 세팅하기
-        _gameManager.SetGears(gears);
-        _gameManager.SetGearImages(gearDatas);
     }
 }

--- a/Assets/Scripts/Character/CookieGearController.cs
+++ b/Assets/Scripts/Character/CookieGearController.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(CookieController))]
+public class CookieGearController : MonoBehaviour
+{
+    [Header("=== 보물 프리팹 생성 ===")]
+    public Transform gearPrefabParent;
+
+    public void SetGear(GameManager gameManager)
+    {
+        string[] gearIds = SaveLoadManager.Data.currentGear;
+        List<GearBase> gears = new List<GearBase>();
+        List<GearData> gearDatas = new List<GearData>();
+
+        foreach (string id in gearIds)
+        {
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            // 추하게 들고오긴 했음.. (알려진 이슈)
+            var gearData = DataTableManager.GearTable.Get(id);
+            var gearPrefab = GameObject
+                .FindGameObjectWithTag("SceneManager")
+                .GetComponent<GachaManager>()
+                .itemList.Find(g => g.itemId == id)
+                .GearPrefab;
+            gearDatas.Add(gearData);
+
+            if (gearData != null && gearPrefab != null)
+            {
+                GameObject gearObj = Instantiate(gearPrefab, gearPrefabParent);
+                gears.Add(gearObj.GetComponent<GearBase>());
+                Debug.Log($"{id} 보물이 {gearPrefabParent.name} 아래에 생성되었습니다.");
+            }
+        }
+
+        gameManager.SetGears(gears);
+        gameManager.SetGearImages(gearDatas);
+    }
+}

--- a/Assets/Scripts/Character/CookieGearController.cs.meta
+++ b/Assets/Scripts/Character/CookieGearController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 807421bf0fb4c7e4ea95e2d051c2e4aa

--- a/Assets/Scripts/Character/CookieHealthController.cs
+++ b/Assets/Scripts/Character/CookieHealthController.cs
@@ -1,0 +1,143 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+[RequireComponent(typeof(CookieController))]
+public class CookieHealthController : MonoBehaviour
+{
+    private readonly float UiMaxHp = 100f;
+    private float MaxHp { get; set; }
+    private readonly float MaxAdditionalHp = 100f;
+    private float _currentHp;
+    private float _additionalHp;
+
+    private readonly float _godModeDurationAfterHit = 2f;
+    private bool _isGodMode = false;
+    private readonly float _healthReduceSpeed = 2f;
+
+    [Header("=== 체력바 관련 Image ===")]
+    [SerializeField]
+    private Image _hpBar;
+
+    [SerializeField]
+    private Image _additionalHpBar;
+
+    [SerializeField]
+    private Image _healthBarShine;
+
+    [HideInInspector]
+    public UnityEvent OnTakeDamage;
+
+    private SpriteRenderer _spriteRenderer;
+    private Coroutine _coGodMode;
+
+    public float CurrentHp
+    {
+        get => _currentHp;
+        private set => _currentHp = Mathf.Clamp(value, 0, MaxHp);
+    }
+
+    public float AdditionalHp
+    {
+        get => _additionalHp;
+        private set => _additionalHp = Mathf.Clamp(value, 0, MaxAdditionalHp);
+    }
+
+    public bool IsGodMode => _isGodMode;
+
+    private float UiHpPercent => CurrentHp / UiMaxHp;
+    private float AdditionalHpPercent => AdditionalHp / MaxAdditionalHp;
+
+    public void Init(float maxHp, SpriteRenderer spriteRenderer)
+    {
+        MaxHp = maxHp;
+        CurrentHp = MaxHp;
+        _spriteRenderer = spriteRenderer;
+    }
+
+    public void TakeDamage(float amount)
+    {
+        if (_isGodMode)
+            return;
+
+        if (_additionalHp > 0)
+        {
+            float reducedAmount = Mathf.Clamp(amount, 0, _additionalHp);
+            AdditionalHp -= reducedAmount;
+            amount -= reducedAmount;
+        }
+
+        CurrentHp -= amount;
+
+        OnTakeDamage?.Invoke();
+        EnableGodMode(_godModeDurationAfterHit);
+    }
+
+    public void EnableGodMode(float duration)
+    {
+        if (_coGodMode != null)
+            StopCoroutine(_coGodMode);
+        _coGodMode = StartCoroutine(CoGodMode(duration));
+    }
+
+    public void StopGodMode()
+    {
+        if (_coGodMode != null)
+            StopCoroutine(_coGodMode);
+        _isGodMode = false;
+        _spriteRenderer.enabled = true;
+    }
+
+    private IEnumerator CoGodMode(float duration)
+    {
+        _isGodMode = true;
+        float godModeTimer = 0f;
+
+        while (godModeTimer <= duration)
+        {
+            godModeTimer += Time.deltaTime;
+            _spriteRenderer.enabled = (int)(godModeTimer / 0.1) % 2 != 0;
+            yield return null;
+        }
+
+        _spriteRenderer.enabled = true;
+        _isGodMode = false;
+    }
+
+    public void RecoverHp(float amount)
+    {
+        CurrentHp += amount;
+    }
+
+    public void GetAdditionalHealth(float amount)
+    {
+        AdditionalHp += amount;
+    }
+
+    private void Update()
+    {
+        if (AdditionalHp > 0)
+        {
+            AdditionalHp -= _healthReduceSpeed * Time.deltaTime;
+        }
+        else
+        {
+            CurrentHp -= _healthReduceSpeed * Time.deltaTime;
+        }
+
+        _hpBar.fillAmount = UiHpPercent;
+        _additionalHpBar.rectTransform.anchoredPosition = new Vector2(
+            _hpBar.rectTransform.anchoredPosition.x
+                + _hpBar.rectTransform.sizeDelta.x * UiHpPercent,
+            _additionalHpBar.rectTransform.anchoredPosition.y
+        );
+        _additionalHpBar.fillAmount = AdditionalHpPercent;
+        _healthBarShine.rectTransform.anchoredPosition = new Vector2(
+            _additionalHpBar.rectTransform.anchoredPosition.x
+                + _additionalHpBar.rectTransform.sizeDelta.x * AdditionalHpPercent
+                - 20,
+            _healthBarShine.rectTransform.anchoredPosition.y
+        );
+    }
+}

--- a/Assets/Scripts/Character/CookieHealthController.cs.meta
+++ b/Assets/Scripts/Character/CookieHealthController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ff69fd05f23e764b890da765b0baa50

--- a/Assets/Scripts/Character/CookieInputController.cs
+++ b/Assets/Scripts/Character/CookieInputController.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+[RequireComponent(typeof(CookieController))]
+public class CookieInputController : MonoBehaviour
+{
+    [Header("=== 점프, 슬라이드 버튼 ===")]
+    [SerializeField]
+    public JumpButton JumpButton;
+
+    [SerializeField]
+    public SlideButton SlideButton;
+
+    [Header("=== 단축키 ===")]
+    [SerializeField]
+    private KeyCode _jumpKey = KeyCode.Space;
+
+    [SerializeField]
+    private KeyCode _slideKey = KeyCode.LeftControl;
+
+    [HideInInspector]
+    public UnityEvent OnJumpKeyDown;
+
+    [HideInInspector]
+    public UnityEvent OnJumpKeyUp;
+
+    [HideInInspector]
+    public UnityEvent WhileJumpKeyPressed;
+
+    [HideInInspector]
+    public UnityEvent OnSlideKeyDown;
+
+    [HideInInspector]
+    public UnityEvent OnSlideKeyUp;
+
+    [HideInInspector]
+    public UnityEvent WhileSlideKeyPressed;
+
+    private GameManager _gameManager;
+
+    public void Init(GameManager gameManager)
+    {
+        _gameManager = gameManager;
+
+        JumpButton.OnButtonDown.AddListener(() => OnJumpKeyDown?.Invoke());
+        JumpButton.OnButtonUp.AddListener(() => OnJumpKeyUp?.Invoke());
+        JumpButton.WhileButtonPressed.AddListener(() => WhileJumpKeyPressed?.Invoke());
+        SlideButton.OnButtonDown.AddListener(() => OnSlideKeyDown?.Invoke());
+        SlideButton.OnButtonUp.AddListener(() => OnSlideKeyUp?.Invoke());
+        SlideButton.WhileButtonPressed.AddListener(() => WhileSlideKeyPressed?.Invoke());
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(_jumpKey))
+            OnJumpKeyDown?.Invoke();
+        if (Input.GetKeyUp(_jumpKey))
+            OnJumpKeyUp?.Invoke();
+        if (Input.GetKey(_jumpKey))
+            WhileJumpKeyPressed?.Invoke();
+
+        if (Input.GetKeyDown(_slideKey))
+            OnSlideKeyDown?.Invoke();
+        if (Input.GetKeyUp(_slideKey))
+            OnSlideKeyUp?.Invoke();
+        if (Input.GetKey(_slideKey))
+            WhileSlideKeyPressed?.Invoke();
+
+        // 임시. A키 누르면 임시 체력 생김
+        if (Input.GetKeyDown(KeyCode.A))
+        {
+            GetComponent<CookieController>().GetAdditionalHealth(10);
+            _gameManager.ActivateDash(5f);
+        }
+    }
+}

--- a/Assets/Scripts/Character/CookieInputController.cs.meta
+++ b/Assets/Scripts/Character/CookieInputController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 445836af562c90745898acfbf1f1a570

--- a/Assets/Scripts/Character/CookieMovementController.cs
+++ b/Assets/Scripts/Character/CookieMovementController.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CookieController))]
+public class CookieMovementController : MonoBehaviour
+{
+    private readonly float _jumpForce = 25f;
+    private readonly float _gravityScale = 8f;
+    private readonly float _linearVelocityMax = 22f;
+
+    private float _ignoreGroundTimer;
+    private readonly float _ignoreGroundDuration = 0.1f;
+
+    private bool _jumpRequested;
+    private CookieState _state;
+
+    private Rigidbody2D _rigidBody;
+    private CookieBehavior _cookieBehavior;
+    private CookieSizeController _sizeController;
+    private CookieController _cookieController;
+
+    public CookieState CurrentState => _state;
+    public float GravityScale => _gravityScale;
+
+    public void Init(
+        CookieBehavior cookieBehavior,
+        CookieSizeController sizeController,
+        CookieController cookieController
+    )
+    {
+        _cookieBehavior = cookieBehavior;
+        _sizeController = sizeController;
+        _cookieController = cookieController;
+
+        _rigidBody = GetComponent<Rigidbody2D>();
+        _rigidBody.gravityScale = _gravityScale;
+        _state = CookieState.Run;
+    }
+
+    public void MarkDead()
+    {
+        _state = CookieState.Death;
+        _rigidBody.simulated = false;
+    }
+
+    public void RequestJump()
+    {
+        _jumpRequested = true;
+    }
+
+    public void RequestSlidingStart()
+    {
+        if (
+            _state == CookieState.Jump
+            || _state == CookieState.DoubleJump
+            || _state == CookieState.Death
+        )
+            return;
+        if (!_cookieController.SlideEnabled)
+            return;
+
+        _state = CookieState.Slide;
+        _sizeController.SetSlidingPosition();
+        _sizeController.SetSlidingCollider();
+        _cookieBehavior.StartSlidingAnimation();
+    }
+
+    public void RequestSlidingEnd()
+    {
+        if (_state != CookieState.Slide)
+            return;
+
+        _state = CookieState.Run;
+        _sizeController.SetStandingPosition();
+        _sizeController.SetStandingCollider();
+        _cookieBehavior.StartRunAnimation();
+    }
+
+    private void FixedUpdate()
+    {
+        _ignoreGroundTimer += Time.deltaTime;
+
+        if (_jumpRequested && _cookieController.JumpEnabled && _state != CookieState.Death)
+        {
+            if (_state == CookieState.Run || _state == CookieState.Slide)
+            {
+                _ignoreGroundTimer = 0f;
+                _state = CookieState.Jump;
+                _cookieBehavior.StartJumpAnimation();
+                _sizeController.SetStandingPosition();
+                _sizeController.SetStandingCollider();
+                _rigidBody.linearVelocity = new Vector2(0, _jumpForce);
+            }
+            else if (_state == CookieState.Jump)
+            {
+                _state = CookieState.DoubleJump;
+                _cookieBehavior.StartDoubleJumpAnimation();
+                _rigidBody.linearVelocity = new Vector2(0, _jumpForce);
+            }
+        }
+        _jumpRequested = false;
+
+        var temp = _rigidBody.linearVelocity;
+        temp.y = Mathf.Clamp(temp.y, -_linearVelocityMax, _linearVelocityMax);
+        _rigidBody.linearVelocity = temp;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (
+            other.CompareTag(Tags.Ground)
+            && (_state == CookieState.Jump || _state == CookieState.DoubleJump)
+            && _ignoreGroundTimer >= _ignoreGroundDuration
+        )
+        {
+            _state = CookieState.Run;
+
+            if (_cookieController.IsDashing)
+                _cookieBehavior.StartDashAnimation();
+            else
+                _cookieBehavior.StartRunAnimation();
+        }
+    }
+}

--- a/Assets/Scripts/Character/CookieMovementController.cs.meta
+++ b/Assets/Scripts/Character/CookieMovementController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3db1b95edaed0dc469a223887d1f347e

--- a/Assets/Scripts/Character/CookieSizeController.cs
+++ b/Assets/Scripts/Character/CookieSizeController.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CookieController), typeof(BoxCollider2D))]
+public class CookieSizeController : MonoBehaviour
+{
+    [Header("=== 실제 충돌 처리할 캡슐 ===")]
+    [SerializeField]
+    private CookieCollisionChecker _collisionCollider;
+
+    private readonly float _slidingYDiff = -0.425f;
+
+    private readonly float _standingColliderYOffset = -0.21f;
+    private readonly float _standingColliderYSize = 1.32f;
+    private readonly float _slidingColliderYOffset = -0.21f;
+    private readonly float _slidingColliderYSize = 0.7f;
+
+    private BoxCollider2D _collider;
+
+    public CookieCollisionChecker CollisionCollider => _collisionCollider;
+
+    private void Awake()
+    {
+        _collider = GetComponent<BoxCollider2D>();
+    }
+
+    public void SetSlidingPosition()
+    {
+        _collisionCollider.SetSlidingPos();
+        transform.position = new Vector3(
+            transform.position.x,
+            transform.position.y + _slidingYDiff,
+            transform.position.z
+        );
+    }
+
+    public void SetStandingPosition()
+    {
+        _collisionCollider.SetStandingPos();
+        transform.position = new Vector3(
+            transform.position.x,
+            transform.position.y - _slidingYDiff,
+            transform.position.z
+        );
+    }
+
+    public void SetSlidingCollider()
+    {
+        _collider.offset = new Vector2(_collider.offset.x, _slidingColliderYOffset);
+        _collider.size = new Vector2(_collider.size.x, _slidingColliderYSize);
+    }
+
+    public void SetStandingCollider()
+    {
+        _collider.offset = new Vector2(_collider.offset.x, _standingColliderYOffset);
+        _collider.size = new Vector2(_collider.size.x, _standingColliderYSize);
+    }
+}

--- a/Assets/Scripts/Character/CookieSizeController.cs.meta
+++ b/Assets/Scripts/Character/CookieSizeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 290b9fbd9cf74a548b2c9abb7a9490e9


### PR DESCRIPTION
## 작업 브랜치
`refactor/129-cookiecontroller-detach`

## 요약
- 594줄짜리 `CookieController`가 체력·입력·크기 변경·점프 물리·장비 세팅 등 모든 책임을 담당하던 구조를 5개의 형제 컴포넌트로 분리
- `CookieController`는 파사드/코디네이터 역할만 수행하며, 외부 public API를 그대로 forwarding하여 외부 호출 코드 변경 없음

## 변경사항
- `CookieHealthController` 신규 — 체력 관리, HP 바 UI, 무적 깜빡임
- `CookieInputController` 신규 — 키/버튼 입력 → UnityEvent 6개
- `CookieSizeController` 신규 — 슬라이딩 시 위치·콜라이더 변경
- `CookieGearController` 신규 — 세이브 데이터 → 장비 프리팹 인스턴스화
- `CookieMovementController` 신규 — 이동 상태 머신 + 점프 물리
- `CookieController` 대폭 슬림화 (454줄 삭제)
- `CookieCollisionChecker` 버그 수정 — `SetStandingOffset` 내부에서 `_slidingColliderYOffset`을 잘못 사용하던 문제 수정
- `BaseCookie.prefab`, `PlayScene.unity` — 신규 컴포넌트 추가 및 SerializeField 재배정

## 관련 이슈
close #129

## 체크리스트
- [x] 로컬 환경에서 빌드 가능
- [x] 디버그 코드 제거 완료 (임시 A키 입력은 기존부터 존재하던 코드로 유지)
- [x] 메타 파일 검토 완료
- [x] CSharpier 포맷 적용 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)