### PR TITLE
feat: 해적맛 쿠키 능력 발동 중 폭탄 투척 구현 (#64)

### DIFF
--- a/Assets/Scripts/Character/CherryBomb.cs
+++ b/Assets/Scripts/Character/CherryBomb.cs
@@ -12,6 +12,9 @@ public class CherryBomb : MonoBehaviour
     public float jellyAddRadius = 0.35f;
     private float splashRadius = 2f;
     private bool isExploded = false;
+
+    // 폭발 시에 젤리 생성 여부 (해적맛 쿠키 등 다른 캐릭터가 재활용할 때 false로 끌 수 있음)
+    public bool spawnJellyEnabled = true;
     public AudioSource bombAudio;
     private Coroutine bombCor;
 
@@ -31,7 +34,8 @@ public class CherryBomb : MonoBehaviour
         {
             Effect();
             isExploded = true;
-            SpawnJelly();
+            if (spawnJellyEnabled)
+                SpawnJelly();
             AudioSource.PlayClipAtPoint(bombAudio.clip, transform.position);
             Collider2D[] obstacles = Physics2D.OverlapCircleAll(transform.position, splashRadius); // 범위 내에 장애물들이 있는지 확인
             foreach (var obstacle in obstacles)
@@ -78,7 +82,8 @@ public class CherryBomb : MonoBehaviour
             isExploded = true;
             if (effectPrefab != null)
                 Effect();
-            SpawnJelly();
+            if (spawnJellyEnabled)
+                SpawnJelly();
             AudioSource.PlayClipAtPoint(bombAudio.clip, transform.position);
             Collider2D[] obstacles = Physics2D.OverlapCircleAll(transform.position, splashRadius);
             foreach (var obstacle in obstacles)

--- a/Assets/Scripts/Character/Pirate/PirateCookieBehavior.cs
+++ b/Assets/Scripts/Character/Pirate/PirateCookieBehavior.cs
@@ -6,6 +6,7 @@ public class PirateCookieBehavior : CookieBehavior
     private Animator _animator;
 
     private readonly string _shipResourcePath = "Prefabs/Character/Pirate/PirateShip";
+    private readonly string _bombResourcePath = "Sprite/Character/Cherry/Jelly/CherryBomb";
     private readonly string _jumpSoundpath = "Sprite/Character/Pirate/Sound/Ch16jump";
     private readonly string _slideSoundpath = "Sprite/Character/Pirate/Sound/Ch16slide";
     private readonly string _reviveSoundpath = "Sprite/Character/Pirate/Sound/G_ghostmode_start";
@@ -25,9 +26,12 @@ public class PirateCookieBehavior : CookieBehavior
         "Animations/Character/Pirate/GhostAnimationController";
 
     private GameObject _pirateShip;
+    private GameObject _bombPrefab;
 
     private readonly float _abilityPeriod = 15f;
     private readonly float _abilityDuration = 2f;
+    private readonly float _bombThrowInterval = 0.4f;
+    private readonly float _bombThrowPower = 8f;
     private float _abilityTimer;
 
     private bool _isUsingAbility;
@@ -35,6 +39,7 @@ public class PirateCookieBehavior : CookieBehavior
 
     private Coroutine _abilityCycleCoroutine;
     private Coroutine _abilityCoroutine;
+    private Coroutine _bombThrowCoroutine;
     private Coroutine _reviveCoroutine;
 
     public override bool UseAbilityProgressBar => true;
@@ -48,6 +53,7 @@ public class PirateCookieBehavior : CookieBehavior
         // 시작 시에, PirateShip 만들고 안보이는 상태로
         _pirateShip = Instantiate(Resources.Load<GameObject>(_shipResourcePath));
         _pirateShip.SetActive(false);
+        _bombPrefab = Resources.Load<GameObject>(_bombResourcePath);
         JumpClip = Resources.Load<AudioClip>(_jumpSoundpath);
         SlideClip = Resources.Load<AudioClip>(_slideSoundpath);
         ReviveClip = Resources.Load<AudioClip>(_reviveSoundpath);
@@ -85,12 +91,61 @@ public class PirateCookieBehavior : CookieBehavior
         // 능력 시작 후 종료
         _pirateShip.SetActive(true);
         _isUsingAbility = true;
+
+        // 능력 발동 동안 일정 간격으로 폭탄 투척
+        _bombThrowCoroutine = StartCoroutine(CoThrowBombs());
+
         yield return new WaitForSeconds(_abilityDuration);
+
+        if (_bombThrowCoroutine != null)
+        {
+            StopCoroutine(_bombThrowCoroutine);
+            _bombThrowCoroutine = null;
+        }
         _isUsingAbility = false;
 
         StartCoroutine(CoDisappear());
 
         _abilityCoroutine = null;
+    }
+
+    private IEnumerator CoThrowBombs()
+    {
+        // 능력 발동 직후 첫 폭탄을 던지고, 이후 _bombThrowInterval 간격으로 반복
+        while (true)
+        {
+            ThrowBomb();
+            yield return new WaitForSeconds(_bombThrowInterval);
+        }
+    }
+
+    private void ThrowBomb()
+    {
+        if (_bombPrefab == null)
+            return;
+
+        // 해적선이 보이면 그 위치에서, 아니면 캐릭터 위치에서 투척
+        Vector3 spawnPos =
+            _pirateShip != null && _pirateShip.activeSelf
+                ? _pirateShip.transform.position
+                : transform.position;
+
+        GameObject bomb = Instantiate(_bombPrefab, spawnPos, Quaternion.identity);
+
+        // CherryBomb 프리팹 재활용. 해적 폭탄은 젤리 생성을 비활성화.
+        CherryBomb bombScript = bomb.GetComponent<CherryBomb>();
+        if (bombScript != null)
+        {
+            bombScript.spawnJellyEnabled = false;
+        }
+
+        // 앞쪽 위로 비스듬히 던지기
+        Rigidbody2D rb = bomb.GetComponent<Rigidbody2D>();
+        if (rb != null)
+        {
+            Vector3 throwDirection = new Vector3(1f, 0.6f, 0f).normalized;
+            rb.AddForce(throwDirection * _bombThrowPower, ForceMode2D.Impulse);
+        }
     }
 
     private IEnumerator CoDisappear()
@@ -155,6 +210,11 @@ public class PirateCookieBehavior : CookieBehavior
         else if (base.DeathCheck() && _reviveCoroutine == null && !_isFirstDeath)
         {
             StopCoroutine(_abilityCycleCoroutine);
+            if (_bombThrowCoroutine != null)
+            {
+                StopCoroutine(_bombThrowCoroutine);
+                _bombThrowCoroutine = null;
+            }
             _abilityCoroutine = null;
             return true;
         }


### PR DESCRIPTION
## 작업 브랜치
`feature/n-pirate-bomb`

## 요약
- 해적맛 쿠키 능력 발동 중(2초) 일정 간격으로 폭탄을 던져 장애물을 파괴하도록 구현
- 기존 `CherryBomb` 프리팹을 재활용하되, 해적 폭탄에서는 젤리 생성을 끄도록 플래그 추가

## 변경사항
- `Assets/Scripts/Character/CherryBomb.cs`
  - `spawnJellyEnabled` 플래그 추가 (기본 `true` → 기존 체리 동작 유지)
  - 폭발 시 `SpawnJelly()` 호출을 플래그로 조건부 실행
- `Assets/Scripts/Character/Pirate/PirateCookieBehavior.cs`
  - `_bombResourcePath`, `_bombThrowInterval(0.4s)`, `_bombThrowPower(8)` 상수 추가
  - `CoAbility()`에서 `CoThrowBombs()` 코루틴 동시 시작 → 능력 종료 시 정리
  - `ThrowBomb()`: 해적선(없으면 캐릭터) 위치에서 `(1, 0.6)` 방향 임펄스로 투척, 폭탄 인스턴스의 `spawnJellyEnabled = false`
  - 진짜 사망 시 `_bombThrowCoroutine` 정리 로직 추가

## 동작
- 15초 주기로 해적선 활성화 → 능력 2초 지속
- 능력 중 0 / 0.4 / 0.8 / 1.2 / 1.6초에 폭탄 1발씩, **총 5발**
- 폭탄은 장애물과 충돌하거나 1.5초 후 폭발하며 주변 장애물 파괴 (CherryBomb 기존 로직 재사용)

## 관련 이슈
close #64

## 체크리스트
- [ ] 로컬 환경에서 빌드 확인
- [x] 디버그 코드 제거
- [x] 메타 파일 변경 없음 (스크립트 내용만 수정)

## 테스트 계획
- [ ] 해적맛 쿠키 선택 후 PlayScene 진입
- [ ] 15초 후 능력 발동 시 해적선과 함께 폭탄이 5발 투척되는지 확인
- [ ] 폭탄이 장애물에 닿거나 시간이 지나면 폭발하여 장애물 파괴되는지 확인
- [ ] 폭발 시 젤리가 생성되지 **않음**을 확인 (해적 폭탄 한정)
- [ ] 체리맛 쿠키 폭탄은 기존대로 젤리가 생성됨을 확인 (회귀 테스트)
- [ ] 부활/사망 흐름에서 폭탄 코루틴이 누수 없이 정리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)