### PR TITLE
fix : 히어로쿠키 대쉬 중 점프/슬라이드 후 Dash 애니메이션 미복귀 수정

### DIFF
--- a/Assets/Scripts/Character/CookieController.cs
+++ b/Assets/Scripts/Character/CookieController.cs
@@ -513,7 +513,11 @@ public class CookieController : MonoBehaviour
 
         SetStandingPosition();
         SetStandingCollider();
-        _cookieBehavior.StartRunAnimation();
+
+        if (IsDashing)
+            _cookieBehavior.StartDashAnimation();
+        else
+            _cookieBehavior.StartRunAnimation();
     }
 
     // 슬라이딩 시에 위치 자연스럽게 변경

--- a/Assets/Scripts/Character/Hero/HeroCookie.cs
+++ b/Assets/Scripts/Character/Hero/HeroCookie.cs
@@ -167,7 +167,6 @@ public class HeroCookie : CookieBehavior
     public override void StartJumpAnimation()
     {
         animator.SetBool("isSlide", false);
-        animator.SetBool("isDash", false);
         animator.SetBool("isGrounded", false);
     }
 


### PR DESCRIPTION
## Summary

- `HeroCookie.StartJumpAnimation()`에서 `isDash=false` 제거 — Dash→Jump 트랜지션은 `isGrounded=false`로 직접 발동, isDash 초기화가 불필요하며 착지 후 복귀 흐름을 깨뜨리는 원인이었음
- `HeroCookie.StartDashAnimation()`에 `isGrounded=true`, `isSlide=false`, `isDouble=false` 추가 — Jump/Slide에서 복귀 시 Run을 경유하는 애니메이터 구조상 `isGrounded=true` 누락으로 Jump 상태에서 빠져나오지 못했음
- `CookieController.RequestSlidingEnd()`에 `IsDashing` 분기 추가 — `OnTriggerEnter2D`(점프 착지)와 동일한 패턴 적용

## Test plan

- [x] 대쉬 활성화(`A`키) 후 점프 → 착지 시 Dash 애니메이션 재개 확인
- [x] 대쉬 활성화 후 슬라이드 → 키 떼기 시 Dash 애니메이션 재개 확인
- [x] 대쉬 활성화 후 더블점프 → 착지 시 Dash 애니메이션 재개 확인
- [x] 대쉬 종료 후 점프/슬라이드 → 복귀 시 Run 애니메이션 정상 재생 (Dash 잔존 없음)
- [x] 이슈 #127 회귀 없음: 슬라이드 중 점프 시 Jump 애니메이션 정상 전환

close #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)